### PR TITLE
Fix email error exception not throwing

### DIFF
--- a/lib/berta/errors/entities.rb
+++ b/lib/berta/errors/entities.rb
@@ -2,8 +2,8 @@ module Berta
   module Errors
     # Module for entity errors
     module Entities
-      autoload :InvalidEntityXMLError, 'berta/errors/entities/invalid_entity_xml_error.rb'
-      autoload :NoUserEmailError, 'berta/errors/entities/no_user_email_error.rb'
+      autoload :InvalidEntityXMLError, 'berta/errors/entities/invalid_entity_xml_error'
+      autoload :NoUserEmailError, 'berta/errors/entities/no_user_email_error'
     end
   end
 end

--- a/lib/berta/errors/entities/invalid_entity_xml_error.rb
+++ b/lib/berta/errors/entities/invalid_entity_xml_error.rb
@@ -1,7 +1,7 @@
 module Berta
   module Errors
     module Entities
-      class InvalidEntityXMLError < StandardError; end
+      class InvalidEntityXMLError < Berta::Errors::StandardError; end
     end
   end
 end

--- a/lib/berta/errors/entities/no_user_email_error.rb
+++ b/lib/berta/errors/entities/no_user_email_error.rb
@@ -1,7 +1,7 @@
 module Berta
   module Errors
     module Entities
-      class NoUserEmailError < StandardError; end
+      class NoUserEmailError < Berta::Errors::StandardError; end
     end
   end
 end

--- a/lib/berta/notification_manager.rb
+++ b/lib/berta/notification_manager.rb
@@ -42,7 +42,6 @@ module Berta
       send_notification(user, user_vms)
     rescue ArgumentError, Berta::Errors::Entities::NoUserEmailError => e
       logger.error e.message
-      logger.error "for user #{user} with id #{uid}"
     else
       user_vms.each(&:update_notified)
     end
@@ -64,7 +63,7 @@ module Berta
     def send_notification(user, vms)
       user_email = user['TEMPLATE/EMAIL']
       user_name = user['NAME']
-      raise Berta::Errors::Entities::NoUserEmailError "User: #{user_name} has no email set" \
+      raise Berta::Errors::Entities::NoUserEmailError, "User: #{user_name} with id: #{user['ID']} has no email set" \
         unless user_email
       mail = Mail.new(email_template.render(Hash,
                                             user_email: user_email,


### PR DESCRIPTION
If use has no email, berta will log error and wont set
notified flag.