### PR TITLE
Example INIT and CRON scripts for packaging

### DIFF
--- a/examples/etc/cron.d/berta
+++ b/examples/etc/cron.d/berta
@@ -1,0 +1,11 @@
+# Cron job running by default every six hours.
+# The lock file can be enabled or disabled via:
+#
+#  service berta-cron start
+#  chkconfig berta-cron on
+#
+# Note that the lock file not existing is a success (and
+# over-all success is needed in order to prevent error
+# messages from cron).
+
+30 */6 * * *	berta	[ ! -f /var/lock/berta-cron ] || /usr/bin/berta

--- a/examples/etc/init.d/berta-cron
+++ b/examples/etc/init.d/berta-cron
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:          berta-cron
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Enable periodic run of berta
+# Description:       This shell script enables the automatic use of berta
+### END INIT INFO
+
+lockfile="/var/lock/berta-cron"
+retval=0
+name=`basename $0`
+
+start() {
+    touch $lockfile
+    echo "Enabling periodic $name"
+    retval=0
+}
+
+stop() {
+    rm -f $lockfile
+    echo "Disabling periodic $name"
+    retval=0
+}
+
+restart() {
+    stop
+    start
+}
+
+case "$1" in
+    start)
+    start
+    ;;
+    stop)
+    stop
+    ;;
+    restart|force-reload)
+    restart
+    ;;
+    reload)
+    ;;
+    condrestart)
+    [ -f "$lockfile" ] && restart
+    ;;
+    status)
+    if [ -f "$lockfile" ] ; then
+        echo "Periodic $name is enabled"
+        retval=0
+    else
+        echo "Periodic $name is disabled"
+        retval=3
+    fi
+    ;;
+    *)
+    echo "Usage: $0 {start|stop|status|restart|reload|force-reload|condrestart}"
+    retval=1
+esac
+
+exit $retval


### PR DESCRIPTION
Scripts included in this pull request will be used in native (i.e., deb/rpm) packages of `berta`. They provide `berta` with basic service-like behavior via CRON.
```bash
service berta-cron start
# or
chkconfig berta-cron on
```